### PR TITLE
checkField() auch bei letztem Feld aufrufen

### DIFF
--- a/src/DieStrasse.java
+++ b/src/DieStrasse.java
@@ -25,6 +25,8 @@ public class DieStrasse extends BouncerApp {
 			checkField();
 			bouncer.move();
 		}
+		//Zusätzlicher Aufruf von checkField() um auch das letzte Feld direkt vor der Wand zu überprüfen
+		checkField();
 	}
 
 	/**


### PR DESCRIPTION
Das letzte Feld direkt vor der Mauer wurde bisher nicht überprüft, da die while-Schleife abgebrochen wird. Sollte das Feld also rot sein, wurde es bisher ignoriert. Durch einen zusätzlichen Aufruf von checkField() nach Abbruch der while-Schleife wird dieser Sonderfall auch beachtet